### PR TITLE
Fix share-modal null-check and preserve console log arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,33 +33,33 @@ const disallowedDomains = [
 ]
 
 class CustomConsole {
-  type(method, message) {
+  type(method, ...messages) {
     if (disallowedDomains.includes(window.location.hostname)) {
       return;
     }
 
     if (typeof console[method] === "function") {
-      console[method](message);
+      console[method](...messages);
     }
     else {
       throw new Error(`Console method ${method} is not supported.`);
     }
   }
 
-  log(message) {
-    this.type("log", message);
+  log(...messages) {
+    this.type("log", ...messages);
   }
 
-  warn(message) {
-    this.type("warn", message);
+  warn(...messages) {
+    this.type("warn", ...messages);
   }
 
-  error(message) {
-    this.type("error", message);
+  error(...messages) {
+    this.type("error", ...messages);
   }
 
-  info(message) {
-    this.type("info", message);
+  info(...messages) {
+    this.type("info", ...messages);
   }
 }
 
@@ -145,7 +145,7 @@ document.addEventListener("DOMContentLoaded", function () {
   if (_openShare) {
     _openShare.addEventListener("click", function () {
       _console.log("🟢 #openShare clicked - opening share modal");
-      if (_shareModal) {
+      if (_shareModal && _shareModalParent) {
         _shareModal.classList.add("active-modal");
         _shareModalParent.classList.remove("hidden");
         _console.log("✅ active-modal added to #share_modal");


### PR DESCRIPTION
### Motivation
- Prevent a runtime exception when opening the share modal if the parent container `#share_social` is missing. 
- Preserve full debug context when logging by ensuring `CustomConsole` forwards all arguments (objects/errors) to the real `console` methods.

### Description
- Change `CustomConsole.type` to accept variadic arguments (`...messages`) and forward them via `console[method](...messages)`, and update `log`, `warn`, `error`, and `info` to accept `...messages`. 
- Tighten the share button handler to require both `#share_modal` and `#share_social` before attempting to add/remove classes, avoiding `null` access.

### Testing
- Ran `npm install --silent` which completed successfully. 
- Ran `npm run build` and the site built successfully (`vite build` completed without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81c70bcb8832091e5bdd99ad970bc)